### PR TITLE
Fix context in fold function

### DIFF
--- a/src/either.js
+++ b/src/either.js
@@ -62,7 +62,7 @@ Either.prototype.traverse = function(f, p) {
 // Transformer
 Either.EitherT = (M) => {
     const EitherT = tagged('run');
-    EitherT.prototype.fold = (f, g) => {
+    EitherT.prototype.fold = function (f, g) {
         return this.run[chain]((o) => M[of](o.fold(f, g)));
     };
     EitherT[of] = (x) => {


### PR DESCRIPTION
Using an arrow function in a prototype method makes the `this` keyword point to the incorrect context. This fixes it by using a standard anonymous function.